### PR TITLE
Add Fiber.dyn and Fiber.setDyn

### DIFF
--- a/src/janet.zig
+++ b/src/janet.zig
@@ -1447,6 +1447,14 @@ pub const Fiber = extern struct {
         return fromC(c.janet_root_fiber());
     }
 
+    pub fn setDyn(name: [*:0]const u8, value: Janet) void {
+        c.janet_setdyn(name, value.toC());
+    }
+
+    pub fn dyn(name: [*:0]const u8) Janet {
+        return Janet.fromC(c.janet_dyn(name));
+    }
+
     pub fn wrap(self: *Fiber) Janet {
         return Janet.fromC(c.janet_wrap_fiber(self.toC()));
     }


### PR DESCRIPTION
This allows you to set the `err` dynamic binding so you can extract errors from `doString` and `doBytes`

Resolves #14 