### PR TITLE
feat(nix): update Nix flake to Zig 0.15.2

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1756256966,
-        "narHash": "sha256-sSVfAOlYIK01ptcDImwkyDVfhGPy/muVa4e7xxbhgho=",
+        "lastModified": 1762997962,
+        "narHash": "sha256-0eIlPSvYDFonxeCA1tQvNCDzCnNsSnWR3+BpBWggzVU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4c202d26483c5ccf3cb95e0053163facde9f047e",
+        "rev": "1b0090a49387aa976b25877614820644b68df07a",
         "type": "github"
       },
       "original": {
@@ -59,11 +59,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1756258936,
-        "narHash": "sha256-rpExIDs2BY97aRERH1Wv9VWke1Qe5wqGPqC3CRVCe8w=",
+        "lastModified": 1762998775,
+        "narHash": "sha256-ieZ3un9r+ch4Tb7jkFQ+St65mUQYz1pBVicsoaBqt4A=",
         "owner": "Cloudef",
         "repo": "zig2nix",
-        "rev": "96e9e4ab353d7617513bd33fef2b76102af322c2",
+        "rev": "649b7febf2bf8a6f6f9105936b3d92db548403cb",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
       # Zig flake helper
       # Check the flake.nix in zig2nix project for more options:
       # <https://github.com/Cloudef/zig2nix/blob/master/flake.nix>
-      env = zig2nix.outputs.zig-env.${system} { zig = zig2nix.outputs.packages.${system}.zig-0_14_1; };
+      env = zig2nix.outputs.zig-env.${system} { zig = zig2nix.outputs.packages.${system}.zig-0_15_2; };
     in with builtins; with env.pkgs.lib; rec {
       # Produces clean binaries meant to be ship'd outside of nix
       # nix build .#foreign


### PR DESCRIPTION
I've updated the Nix flake to use Zig 0.15.2 as noted in #17 but there are some compilation errors when running `zig build test`. I guess we can ignore these for now as they are not related to this PR changeset? @greenfork 

```sh
build.zig:29:48: error: struct 'array_list.Aligned([]const u8,null)' has no member named 'init'
    var janet_flags = std.ArrayList([]const u8).init(ally);
                      ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
/nix/store/9gzf0jfgavddpajk6dsgi5npxwrlqci5-zig-0.15.2/lib/std/array_list.zig:606:12: note: struct declared here
    return struct {
           ^~~~~~
referenced by:
    runBuild__anon_23508: /nix/store/9gzf0jfgavddpajk6dsgi5npxwrlqci5-zig-0.15.2/lib/std/Build.zig:2214:33
    main: /nix/store/9gzf0jfgavddpajk6dsgi5npxwrlqci5-zig-0.15.2/lib/compiler/build_runner.zig:366:29
    5 reference(s) hidden; use '-freference-trace=7' to see all references
```

Also sorry it took longer than expected, I've completely forgotten about it yesterday as I was really tired 😅 